### PR TITLE
Bump bytestring dependency upper bound to < 0.12

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -52,7 +52,7 @@ Library
   C-sources:         cbits/fnv.c
 
   Build-depends:     base       >= 4.5      && < 4.15
-                   , bytestring >= 0.9      && < 0.11
+                   , bytestring >= 0.9      && < 0.12
                    , deepseq    >= 1.3      && < 1.5
                    , text       >= 0.12     && < 1.3
                    , ghc-prim


### PR DESCRIPTION
Found myself needing this bumped to build a project.