### PR TITLE
Make hashable-examples a test-suite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ See also https://pvp.haskell.org/faq
 
  * Use FNV-1 constants.
 
+ * Make `hashable-examples` a test-suite
+
 ## Version 1.3.0.0
 
  * Semantic change of `Hashable Arg` instance to *not* hash the second

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -37,11 +37,6 @@ Flag sse41
   Default: False
   Manual: True
 
-Flag examples
-  Description: Build example modules
-  Default: False
-  Manual: True
-
 Library
   Exposed-modules:   Data.Hashable
                      Data.Hashable.Lifted
@@ -172,11 +167,9 @@ benchmark benchmarks
 
   Default-Language:  Haskell2010
 
-Executable hashable-examples
-  if flag(examples)
-    build-depends: base, hashable
-  else
-    buildable: False
+test-suite hashable-examples
+  type:              exitcode-stdio-1.0
+  build-depends: base, hashable, ghc-prim
   hs-source-dirs: examples
   main-is: Main.hs
   Default-Language:  Haskell2010


### PR DESCRIPTION
Thus it is build by CI.
Also we can remove a flag which has no effect on a library
whatsoever.