### PR TITLE
Fix FNV bug on 64-bit Windows (hashes being cut off to 32-bit)

### DIFF
--- a/cbits/fnv.c
+++ b/cbits/fnv.c
@@ -32,11 +32,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "MachDeps.h"
+#include <stdint.h>
 
 #if WORD_SIZE_IN_BITS == 64
 #define FNV_PRIME 1099511628211
+#define FNV_SIGNED int64_t
+#define FNV_UNSIGNED uint64_t
 #else
 #define FNV_PRIME 16777619
+#define FNV_SIGNED int32_t
+#define FNV_UNSIGNED uint32_t
 #endif
 
 /* FNV-1 hash
@@ -44,11 +49,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The FNV-1 hash description: http://isthe.com/chongo/tech/comp/fnv/
  * The FNV-1 hash is public domain: http://isthe.com/chongo/tech/comp/fnv/#public_domain
  */
-long hashable_fnv_hash(const unsigned char* str, long len, long salt) {
+FNV_SIGNED hashable_fnv_hash(const unsigned char* str, FNV_SIGNED len, FNV_SIGNED salt) {
 
-  unsigned long hash = salt;
+  FNV_UNSIGNED hash = salt;
   while (len--) {
-    hash = (hash * 16777619) ^ *str++;
+    hash = (hash * FNV_PRIME) ^ *str++;
   }
 
   return hash;
@@ -57,6 +62,6 @@ long hashable_fnv_hash(const unsigned char* str, long len, long salt) {
 /* Used for ByteArray#s. We can't treat them like pointers in
    native Haskell, but we can in unsafe FFI calls.
  */
-long hashable_fnv_hash_offset(const unsigned char* str, long offset, long len, long salt) {
+FNV_SIGNED hashable_fnv_hash_offset(const unsigned char* str, FNV_SIGNED offset, FNV_SIGNED len, FNV_SIGNED salt) {
   return hashable_fnv_hash(str + offset, len, salt);
 }

--- a/src/Data/Hashable/Class.hs
+++ b/src/Data/Hashable/Class.hs
@@ -122,10 +122,8 @@ import GHC.Fingerprint.Type(Fingerprint(..))
 #endif
 
 #if MIN_VERSION_base(4,5,0)
-import Foreign.C (CLong(..))
 import Foreign.C.Types (CInt(..))
 #else
-import Foreign.C (CLong)
 import Foreign.C.Types (CInt)
 #endif
 
@@ -816,8 +814,13 @@ hashPtrWithSalt p len salt =
     fromIntegral `fmap` c_hashCString (castPtr p) (fromIntegral len)
     (fromIntegral salt)
 
+#if WORD_SIZE_IN_BITS == 64
 foreign import ccall unsafe "hashable_fnv_hash" c_hashCString
-    :: CString -> CLong -> CLong -> IO CLong
+    :: CString -> Int64 -> Int64 -> IO Int64
+#else
+foreign import ccall unsafe "hashable_fnv_hash" c_hashCString
+    :: CString -> Int32 -> Int32 -> IO Int32
+#endif
 
 -- | Compute a hash value for the content of this 'ByteArray#',
 -- beginning at the specified offset, using specified number of bytes.
@@ -844,8 +847,13 @@ hashByteArrayWithSalt ba !off !len !h =
     fromIntegral $ c_hashByteArray ba (fromIntegral off) (fromIntegral len)
     (fromIntegral h)
 
+#if WORD_SIZE_IN_BITS == 64
 foreign import ccall unsafe "hashable_fnv_hash_offset" c_hashByteArray
-    :: ByteArray# -> CLong -> CLong -> CLong -> CLong
+    :: ByteArray# -> Int64 -> Int64 -> Int64 -> Int64
+#else
+foreign import ccall unsafe "hashable_fnv_hash_offset" c_hashByteArray
+    :: ByteArray# -> Int32 -> Int32 -> Int32 -> Int32
+#endif
 
 -- | Combine two given hash values.  'combine' has zero as a left
 -- identity.


### PR DESCRIPTION
I observed an issue in my app where many input values (of a nested record type) were being hashed to the same value, and eventually determined it was only happening on Windows. After tracing the problem back, I noticed `Text` values were always being hashed to 32-bit values, and that when I combined the hashes of `(record, text)`, the input record hash (used as salt) was also being cut off to 32-bit.

That led me to these issues with `fnv.c`. It is using `long` which is 32 bits on 64-bit Windows. However Haskell `Int`, as well as `WORD_SIZE_IN_BITS`, are 64. So hashes in general are 64-bit, but then getting improperly cut off when they interact with this code, such as through `Text` and other byte array types. I also noticed the `FNV_PRIME` constant added recently was not actually being used; I assume it was supposed to replace the numeric constant in the function below.

I tested that this fixes the hash behavior in my app, but I have not tested on a 32-bit platform yet.