### PR TITLE
Fix test for -f random-initial-seed

### DIFF
--- a/tests/Regress.hs
+++ b/tests/Regress.hs
@@ -41,7 +41,7 @@ regressions = [] ++
         hs @=? nub hs
 #if WORD_SIZE_IN_BITS == 64
     , testCase "64 bit Text" $ do
-        hash ("hello world" :: Text) @=? 2668910425102664189
+        hashWithSalt (-3750763034362895579) ("hello world" :: Text) @=? 2668910425102664189
 #endif
     ]
   where


### PR DESCRIPTION
This fixes the tests when running with:

    cabal new-run hashable-tests -f random-initial-seed

I'd like to run these tests when patching hashable with nix.
By changing this into a hardcoded salt it works again.
I think this still guards against the regression
(although the test case isn't very descriptive)