### PR TITLE
Support text-2.0

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -87,7 +87,7 @@ library
     , containers  >=0.4.2.1 && <0.7
     , deepseq     >=1.3     && <1.5
     , ghc-prim
-    , text        >=0.12    && <1.3
+    , text        >=0.12    && <2.1
 
   if !impl(ghc >=9.2)
     build-depends: base-orphans >=0.8.6

--- a/tests/Regress.hs
+++ b/tests/Regress.hs
@@ -48,7 +48,12 @@ regressions = [] ++
         hs @=? nub hs
 #if WORD_SIZE_IN_BITS == 64
     , testCase "64 bit Text" $ do
-        hash ("hello world" :: Text) @=? -3875242662334356092
+        hash ("hello world" :: Text) @=?
+#if MIN_VERSION_text(2,0,0)
+            4078614214911247440
+#else
+            -3875242662334356092
+#endif
 #endif
     , F.testGroup "concatenation"
         [ testCase "String" $ do


### PR DESCRIPTION
Closes #214, supersedes #216. Tested with 

```cabal
packages: .
tests: True

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: 2.0-rc1
```

I've uploaded `text-2.0-rc1` on Hackage: https://hackage.haskell.org/package/text-2.0/candidate