### PR TITLE
Update hashable.cabal

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -84,7 +84,7 @@ library
   include-dirs:     include
   hs-source-dirs:   src
   build-depends:
-      base        >=4.5     && <4.17
+      base        >=4.5     && <4.18
     , bytestring  >=0.9     && <0.12
     , containers  >=0.4.2.1 && <0.7
     , deepseq     >=1.3     && <1.5
@@ -96,7 +96,7 @@ library
 
   -- Integer internals
   if impl(ghc >=9)
-    build-depends: ghc-bignum >=1.0 && <1.3
+    build-depends: ghc-bignum >=1.0 && <1.4
 
     if !impl(ghc >=9.0.2)
       build-depends: ghc-bignum-orphans >=0.1 && <0.2


### PR DESCRIPTION
relax bounds on 'base' and 'ghc-bignum' for GHC-9.4.0