### PR TITLE
Add instance for OsString

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 See also https://pvp.haskell.org/faq
 
+## Version 1.4.2.0
+
+ * Add instance for `System.OsString.Internal.Types.PosixString`.
+ * Add instance for `System.OsString.Internal.Types.WindowsString`.
+ * Add instance for `System.OsString.OsString`.
+
 ## Version 1.4.1.0
 
  * Add instance for `Data.Array.Byte.ByteArray`.

--- a/hashable-bench/hashable-bench.cabal
+++ b/hashable-bench/hashable-bench.cabal
@@ -80,6 +80,7 @@ library
     , bytestring  >=0.9  && <0.12
     , containers  >=0.4.2.1 && <0.7
     , deepseq     >=1.3  && <1.5
+    , filepath    >=1.3.0.0 && <1.5
     , ghc-prim
     , text        >=0.12 && <1.3
 

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               hashable
-version:            1.4.1.0
+version:            1.4.2.0
 synopsis:           A class for types that can be converted to a hash value
 description:
   This package defines a class, 'Hashable', for types that
@@ -85,12 +85,13 @@ library
   include-dirs:     include
   hs-source-dirs:   src
   build-depends:
-      base        >=4.5     && <4.18
-    , bytestring  >=0.9     && <0.12
-    , containers  >=0.4.2.1 && <0.7
-    , deepseq     >=1.3     && <1.5
+      base        >=4.5       && <4.18
+    , bytestring  >=0.9       && <0.12
+    , containers  >=0.4.2.1   && <0.7
+    , deepseq     >=1.3       && <1.5
+    , filepath    >=1.3.0.0   && <1.5
     , ghc-prim
-    , text        >=1.2.3.0 && <1.3 || >=2.0 && <2.1
+    , text        >=1.2.3.0   && <1.3  || >=2.0 && <2.1
 
   if !impl(ghc >=9.2)
     build-depends: base-orphans >=0.8.6

--- a/src/Data/Hashable/Class.hs
+++ b/src/Data/Hashable/Class.hs
@@ -138,6 +138,12 @@ import qualified Data.ByteString.Lazy.Internal as BL  -- foldlChunks
 
 #if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Short.Internal as BSI
+
+-- OsString internally uses ShortByteString
+#if MIN_VERSION_filepath(1,4,100)
+import System.OsString.Internal.Types (OsString (..), PosixString (..), WindowsString (..))
+#endif
+
 #endif
 
 #ifdef VERSION_ghc_bignum
@@ -724,6 +730,21 @@ instance Hashable BL.ByteString where
 instance Hashable BSI.ShortByteString where
     hashWithSalt salt sbs@(BSI.SBS ba) =
         hashByteArrayWithSalt ba 0 (BSI.length sbs) (hashWithSalt salt (BSI.length sbs))
+
+#if MIN_VERSION_filepath(1,4,100)
+-- | @since 1.4.2.0
+instance Hashable PosixString where
+    hashWithSalt salt (PosixString s) = hashWithSalt salt s
+
+-- | @since 1.4.2.0
+instance Hashable WindowsString where
+    hashWithSalt salt (WindowsString s) = hashWithSalt salt s
+
+-- | @since 1.4.2.0
+instance Hashable OsString where
+    hashWithSalt salt (OsString s) = hashWithSalt salt s
+#endif
+
 #endif
 
 #if MIN_VERSION_text(2,0,0)


### PR DESCRIPTION
Resolves #254.

Since `OsPath` is a [type synonym](https://hackage.haskell.org/package/filepath-1.4.100.0/docs/System-OsPath.html#t:OsPath) for `OsString`, and `OsString` is a [`ShortByteString`](https://hackage.haskell.org/package/filepath-1.4.100.0/docs/System-OsString-Internal-Types.html#t:OsString), the most straightforward way to add the instance seems to be to reuse the `ShortByteString` instance.

A few thoughts:

1. CPP could be added to control the new dependency. I chose not to do this but am fine with whatever the maintainers think.
2. Is there a better way to do this?

    ```haskell
    instance Hashable OsString where
        hashWithSalt salt = hashWithSalt salt . getSBS . getOsString
          where
    #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
            getSBS = getWindowsString
    #else
            getSBS = getPosixString
    #endif
    ```
    
    I was surprised that I could not find a `OsString -> ShortByteString` function, even in an internal module (is there one?), though maybe exposing that would be antithetical to AFP's goals.
3. I bumped the minor version since it is just adding a new instance, but perhaps it warrants a major bump due to the new dependencies (e.g. `filepath`, transitive `exceptions`). I'm not sure what [PVP](https://pvp.haskell.org/) has to say on this.