### PR TITLE
Fix #271: Don't define `hash` for tuples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 See also https://pvp.haskell.org/faq
 
+## Version 1.4.3.0
+
+ * Export `defaultHashWithSalt` and `defaultHash`.
+ * Fix issue of tuples with 0 first component causing all-zero state.
+
 ## Version 1.4.2.0
 
  * Fix the foreign signature of `getThreadId`

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,7 +1,6 @@
 cabal-version:      1.12
 name:               hashable
-version:            1.4.2.0
-x-revision:         1
+version:            1.4.3.0
 synopsis:           A class for types that can be converted to a hash value
 description:
   This package defines a class, 'Hashable', for types that

--- a/src/Data/Hashable.hs
+++ b/src/Data/Hashable.hs
@@ -60,6 +60,9 @@ module Data.Hashable
     , hashByteArray
     , hashByteArrayWithSalt
 
+    , defaultHashWithSalt
+    , defaultHash
+
     -- * Caching hashes
     , Hashed
     , hashed

--- a/src/Data/Hashable/Class.hs
+++ b/src/Data/Hashable/Class.hs
@@ -50,6 +50,7 @@ module Data.Hashable.Class
     , hashByteArray
     , hashByteArrayWithSalt
     , defaultHashWithSalt
+    , defaultHash
       -- * Higher Rank Functions
     , hashWithSalt1
     , hashWithSalt2
@@ -228,7 +229,7 @@ class Eq a => Hashable a where
     -- Instances might want to implement this method to provide a more
     -- efficient implementation than the default implementation.
     hash :: a -> Int
-    hash = hashWithSalt defaultSalt
+    hash = defaultHash
 
     default hashWithSalt :: (Generic a, GHashable Zero (Rep a)) => Int -> a -> Int
     hashWithSalt = genericHashWithSalt
@@ -293,8 +294,18 @@ defaultLiftHashWithSalt h = liftHashWithSalt2 hashWithSalt h
 -- cannot also provide a default implementation for that method for
 -- the non-generic instance use case. Instead we provide
 -- 'defaultHashWith'.
+--
+-- @since 1.4.3.0
+--
 defaultHashWithSalt :: Hashable a => Int -> a -> Int
 defaultHashWithSalt salt x = salt `hashInt` hash x
+
+-- | Default implementation of 'hash' based on 'hashWithSalt'.
+--
+-- @since 1.4.3.0
+--
+defaultHash :: Hashable a => a -> Int
+defaultHash = hashWithSalt defaultSalt
 
 -- | Transform a value into a 'Hashable' value, then hash the
 -- transformed value using the given salt.
@@ -533,7 +544,6 @@ instance Hashable2 Either where
     liftHashWithSalt2 _ h s (Right b) = s `hashInt` distinguisher `h` b
 
 instance (Hashable a1, Hashable a2) => Hashable (a1, a2) where
-    hash (a1, a2) = hash a1 `hashWithSalt` a2
     hashWithSalt = hashWithSalt1
 
 instance Hashable a1 => Hashable1 ((,) a1) where
@@ -543,7 +553,6 @@ instance Hashable2 (,) where
     liftHashWithSalt2 h1 h2 s (a1, a2) = s `h1` a1 `h2` a2
 
 instance (Hashable a1, Hashable a2, Hashable a3) => Hashable (a1, a2, a3) where
-    hash (a1, a2, a3) = hash a1 `hashWithSalt` a2 `hashWithSalt` a3
     hashWithSalt = hashWithSalt1
 
 instance (Hashable a1, Hashable a2) => Hashable1 ((,,) a1 a2) where
@@ -555,8 +564,6 @@ instance Hashable a1 => Hashable2 ((,,) a1) where
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4) =>
          Hashable (a1, a2, a3, a4) where
-    hash (a1, a2, a3, a4) = hash a1 `hashWithSalt` a2
-                            `hashWithSalt` a3 `hashWithSalt` a4
     hashWithSalt = hashWithSalt1
 
 instance (Hashable a1, Hashable a2, Hashable a3) => Hashable1 ((,,,) a1 a2 a3) where
@@ -568,9 +575,6 @@ instance (Hashable a1, Hashable a2) => Hashable2 ((,,,) a1 a2) where
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5)
       => Hashable (a1, a2, a3, a4, a5) where
-    hash (a1, a2, a3, a4, a5) =
-        hash a1 `hashWithSalt` a2 `hashWithSalt` a3
-        `hashWithSalt` a4 `hashWithSalt` a5
     hashWithSalt s (a1, a2, a3, a4, a5) =
         s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5
@@ -589,9 +593,6 @@ instance (Hashable a1, Hashable a2, Hashable a3)
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5,
           Hashable a6) => Hashable (a1, a2, a3, a4, a5, a6) where
-    hash (a1, a2, a3, a4, a5, a6) =
-        hash a1 `hashWithSalt` a2 `hashWithSalt` a3
-        `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6
     hashWithSalt s (a1, a2, a3, a4, a5, a6) =
         s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6
@@ -611,9 +612,6 @@ instance (Hashable a1, Hashable a2, Hashable a3,
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5,
           Hashable a6, Hashable a7) =>
          Hashable (a1, a2, a3, a4, a5, a6, a7) where
-    hash (a1, a2, a3, a4, a5, a6, a7) =
-        hash a1 `hashWithSalt` a2 `hashWithSalt` a3
-        `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6 `hashWithSalt` a7
     hashWithSalt s (a1, a2, a3, a4, a5, a6, a7) =
         s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6 `hashWithSalt` a7

--- a/tests/Regress.hs
+++ b/tests/Regress.hs
@@ -7,7 +7,7 @@ module Regress (regressions) where
 import qualified Test.Framework as F
 import Control.Monad (when)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (assertFailure, (@=?))
+import Test.HUnit (Assertion, assertFailure, (@=?))
 import GHC.Generics (Generic)
 import Data.List (nub)
 import Data.Fixed (Pico)
@@ -27,6 +27,11 @@ import Data.Hashable
 
 #include "MachDeps.h"
 
+assertInequal :: Eq a => String -> a -> a -> Assertion
+assertInequal msg x y
+    | x == y    = assertFailure msg
+    | otherwise = return ()
+
 regressions :: [F.Test]
 regressions = [] ++
 #ifdef HAVE_MMAP
@@ -42,6 +47,11 @@ regressions = [] ++
         , testCase "3" $ nullaryCase 3 S3
         , testCase "4" $ nullaryCase 4 S4
         ]
+
+    , testCase "Zero tuples: issue 271" $ do
+        assertInequal "Hash of (0,0) != 0" (hash (0 :: Int, 0 :: Int)) 0
+        assertInequal "Hash of (0,0,0) != 0" (hash (0 :: Int, 0 :: Int, 0 :: Int)) 0
+
     , testCase "Generic: Peano https://github.com/tibbe/hashable/issues/135" $ do
         let ns = take 20 $ iterate S Z
         let hs = map hash ns


### PR DESCRIPTION
as `hash (0, ....)` would easily cause all zeros state.

- Export `defaultHash` and `defaultHashWithSalt`