### PR TITLE
added os-string flag to cabal file

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -64,6 +64,13 @@ flag random-initial-seed
   manual:      True
   default:     False
 
+flag os-string
+  description:
+    Use the new os-string package and filepath pacakage version >= 1.5.0.0
+
+  manual:      False
+  default:     False
+
 library
   exposed-modules:
     Data.Hashable
@@ -84,9 +91,16 @@ library
     , bytestring  >=0.10.8.2 && <0.13
     , containers  >=0.5.10.2 && <0.7
     , deepseq     >=1.4.3.0  && <1.6
-    , filepath    >=1.4.1.2  && <1.5
     , ghc-prim
     , text        >=1.2.3.0  && <1.3  || >=2.0 && <2.2
+
+  if flag(os-string)
+    build-depends:
+        filepath >=1.5.0.0 && <1.6
+      , os-string >=2.0.2 && <3
+  else
+    build-depends:
+        filepath    >=1.4.1.2  && <1.5
 
   if !impl(ghc >=9.2)
     build-depends: base-orphans >=0.8.6 && <0.10

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -97,7 +97,7 @@ library
   if flag(os-string)
     build-depends:
         filepath >=1.5.0.0 && <1.6
-      , os-string >=2.0.2 && <3
+      , os-string >=2.0.2 && <2.1
   else
     build-depends:
         filepath    >=1.4.1.2  && <1.5


### PR DESCRIPTION
Allows using filepath version >=1.5.0.0 and the new os-string package