### PR TITLE
Exclude xxHash-0.8.2 folder from language detection scan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+xxHash-0.8.2/* linguist-detectable=false


### PR DESCRIPTION
GitHub classifies this repo as C++ one currently

<img width="584" alt="image" src="https://github.com/haskell-unordered-containers/hashable/assets/1331647/d681aef6-5b06-4dd0-ae0f-788db034a58b">
