### PR TITLE
Turn arch-native flag off by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 See also https://pvp.haskell.org/faq
 
+## Version 1.4.7.0
+
+  * Make `arch-native` disabled by default.
+
 ## Version 1.4.6.0
 
   * Use GND&DerivingVia to derive `newtype` intances (`Data.Semigroup`, `Data.Monoid`, `Identity` etc).

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               hashable
-version:            1.4.6.0
+version:            1.4.7.0
 synopsis:           A class for types that can be converted to a hash value
 description:
   This package defines a class, 'Hashable', for types that can be converted to a hash value.
@@ -61,10 +61,11 @@ flag integer-gmp
 flag arch-native
   description:
     Use @-march=native@ when compiling C sources.
-    You may need to disable this flag if you are building distributable binaries
+    Portable implementation is 15-50% slower.
+    Consider enabling this flag if hashing performance is important.
 
   manual:      True
-  default:     True
+  default:     False
 
 flag random-initial-seed
   description:


### PR DESCRIPTION
In benchmarks it's own, because if you care about speed, you'll enable it.

Closes #310 